### PR TITLE
Log messages consistency ++

### DIFF
--- a/beamStratum.cpp
+++ b/beamStratum.cpp
@@ -96,7 +96,7 @@ void beamStratum::connect() {
 // Once the physical connection is there start a TLS handshake
 void beamStratum::handleConnect(const boost::system::error_code& err, tcp::resolver::iterator endpoint_iterator) {
 	if (!err) {
-	cout << "Connected to node. Starting TLS handshake." << endl;
+	cout << "Node connection: ok" << endl;
 
       	// The connection was successful. Do the TLS handshake
 	socket->async_handshake(boost::asio::ssl::stream_base::client,boost::bind(&beamStratum::handleHandshake, this, boost::asio::placeholders::error));
@@ -126,7 +126,7 @@ void beamStratum::handleHandshake(const boost::system::error_code& error) {
 		boost::asio::async_read_until(*socket, responseBuffer, "\n",
 		boost::bind(&beamStratum::readStratum, this, boost::asio::placeholders::error));
 
-		cout << "TLS Handshake sucess" << endl;
+		cout << "TLS Handshake:   ok" << endl;
 		
 		// The connection was successful. Send the login request
 		std::stringstream json;
@@ -195,7 +195,7 @@ void beamStratum::readStratum(const boost::system::error_code& err) {
 							cout << "Solution for work id " << jsonTree.get<string>("id") << " accepted" << endl;
 							sharesAcc++;
 						} else {
-							cout << "Warning: Solution for work id " << jsonTree.get<string>("id") << " not accepted" << endl;
+							cout << "Warning: Solution for work id " << jsonTree.get<string>("id") << " rejected" << endl;
 							sharesRej++;
 						}
 					}
@@ -216,7 +216,7 @@ void beamStratum::readStratum(const boost::system::error_code& err) {
 					powDiff = beam::Difficulty(stratDiff);
 					updateMutex.unlock();	
 
-					cout << "New work received with id " << workId << " at difficulty " << std::fixed << std::setprecision(0) << powDiff.ToFloat() << endl;	
+					cout << "New job: " << workId << "  Difficulty: " << std::fixed << std::setprecision(0) << powDiff.ToFloat() << endl;	
 				}
 
 				// Cancel a running job
@@ -230,13 +230,13 @@ void beamStratum::readStratum(const boost::system::error_code& err) {
 				}
 				t_current = time(NULL);
 
-				cout << "Solutions (A/R): " << sharesAcc << " / " << sharesRej << " Uptime: " << (int)(t_current-t_start) << " sec" << endl; 
+				cout << "Solutions (Accepted/Rejected): " << sharesAcc << " / " << sharesRej << " Uptime: " << (int)(t_current-t_start) << " sec" << endl; 
 			}
 
 			
 
 		} catch(const pt::ptree_error &e) {
-			cout << "Json parse error: " << e.what() << endl; 
+			cout << "Json parse error when reading Stratum node: " << e.what() << endl; 
 		}
 
 		// Prepare to continue reading

--- a/clHost.cpp
+++ b/clHost.cpp
@@ -49,7 +49,7 @@ void CL_CALLBACK CCallbackFunc(cl_event ev, cl_int err , void* data) {
 
 // Function to load the OpenCL kernel and prepare our device for mining
 void clHost::loadAndCompileKernel(cl::Device &device, uint32_t pl, bool use3G) {
-	cout << "   Loading and compiling Beam OpenCL Kernel" << endl;
+	cout << "          Beam OpenCL kernel: loading & compiling" << endl;
 
 	// reading the kernel
 	string progStr = string(__equihash_150_5_cl, __equihash_150_5_cl_len); 
@@ -72,7 +72,7 @@ void clHost::loadAndCompileKernel(cl::Device &device, uint32_t pl, bool use3G) {
 
 	// Check if the build was Ok
 	if (!err) {
-		cout << "   Build sucessfull. " << endl;
+		cout << "          Beam OpenCL kernel: build sucessfully" << endl;
 
 		// Store the device and create a queue for it
 		cl_command_queue_properties queue_prop = 0;  
@@ -193,28 +193,28 @@ void clHost::detectPlatFormDevices(vector<int32_t> selDev, bool allowCPU, bool f
 				uint64_t needed_4G = 7* ((uint64_t) 570425344) + 4096 + 196608 + 1296;
 				uint64_t needed_3G = 4* ((uint64_t) 556793856) + ((uint64_t) 835190784) + 4096 + 196608 + 1296;
 
-				cout << "   Device reports " << deviceMemory / (1024*1024) << "MByte total memory" << endl;
-
+				cout << "          Total memory: " << deviceMemory / (1024*1024) << " MByte" << endl;
+				
 				if ( hasExtension(nDev[di], "cl_amd_device_attribute_query") ) {
 					uint64_t freeDeviceMemory;
 				 	nDev[di].getInfo(0x4039, &freeDeviceMemory);  // CL_DEVICE_GLOBAL_FREE_MEMORY_AMD
 					freeDeviceMemory *= 1024;
-					cout << "   Device reports " << freeDeviceMemory / (1024*1024) << "MByte free memory (AMD)" << endl;
+					cout << "          Free memory:  " << freeDeviceMemory / (1024*1024) << " MByte" << endl;
 					deviceMemory = min<uint64_t>(deviceMemory, freeDeviceMemory);
 				}
 				
 
 				if ((deviceMemory > needed_4G) && (!force3G)) {
-					cout << "   Memory check for 4G kernel passed" << endl;
+					cout << "          Beam OpenCL kernel: using 4 Gbyte" << endl;
 					loadAndCompileKernel(nDev[di], pl, false);
 				} else if (deviceMemory > needed_3G) {
-					cout << "   Memory check for 3G kernel passed" << endl;
+					cout << "          Beam OpenCL kernel: using 3 Gbyte" << endl;
 					loadAndCompileKernel(nDev[di], pl, true);
 				}  else {
 					cout << "   Memory check failed, required minimum memory: " << needed_3G/(1024*1024) << endl;
 				}
 			} else {
-				cout << "   Device will not be used, it was not included in --devices parameter." << endl;
+				cout << "          Device not used. Not included in --devices parameter." << endl;
 			}
 
 			curDiv++; 

--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,12 @@
 #include "beamStratum.h"
 #include "clHost.h"
 
+// Defining global variables
+// Set version number alogritm & here
+const string StrVersionNumber = "v1.0.63";
+const string StrVersionDate = "Jan 6th 2019";
+const string alogritm = "Equihash 150,5";
+
 inline vector<string> &split(const string &s, char delim, vector<string> &elems) {
     stringstream ss(s);
     string item;
@@ -76,7 +82,7 @@ uint32_t cmdParser(vector<string> args, string &host, string &port, string &apiC
 			}
 	
 			if (args[i].compare("--version")  == 0) {
-				cout << "1.0.63 for BEAM main network (Jan 6th 2019)" << endl;
+				cout << StrVersionNumber << " for BEAM main network " << "(" << StrVersionDate << ")" << endl;
 				exit(0);
 			}
 		}
@@ -109,9 +115,20 @@ int main(int argc, char* argv[]) {
 	uint32_t parsing = cmdParser(cmdLineArgs, host, port, apiCred, debug, cpuMine, devices, force3G);
 
 	cout << "-====================================-" << endl;
-	cout << "   BEAM Equihash 150/5 OpenCL miner   " << endl;
-	cout << "        v1.0.63, Jan 6th 2019         " << endl;
+	cout << "                                      " << endl;
+	cout << "      BEAM Equihash OpenCL miner      " << endl;
+	cout << "       version:   " + StrVersionNumber << endl;
+	cout << "       date:      " + StrVersionDate << endl;
+	cout << "       algorithm: " + alogritm << endl;
+	cout << "                                      " << endl;
 	cout << "-====================================-" << endl;
+	cout << "" << endl;	
+	cout << "Parameters: " << endl;
+	cout << " --server:      " << host << ":" << port << endl;	
+	cout << " --key:         " << apiCred << endl;
+	cout << " --enable-cpu:  " << std::boolalpha << cpuMine << endl;
+	cout << " --force3G:     " << std::boolalpha << force3G << endl;	
+	cout << " --debug:       " << std::boolalpha << debug << endl;
 
 	if (parsing != 0) {
 		if (parsing & 0x1) {
@@ -127,6 +144,7 @@ int main(int argc, char* argv[]) {
 		cout << " --server <server>:<port>	The BEAM stratum server and port to connect to (required)" << endl;
 		cout << " --key <key>			The BEAM stratum server API key (required)" << endl;
 		cout << " --devices <numbers>		A comma seperated list of devices that should be used for mining (default: all in system)" << endl; 
+		cout << " --debug			Enable debug mode - verbose information will be displayed" << endl;
 		cout << " --enable-cpu			Enable mining on OpenCL CPU devices" << endl;
 		cout << " --force3G			Force miner to use max 3G for all installed GPUs" << endl;
 		cout << " --version			Prints the version number" << endl;


### PR DESCRIPTION
Log messages consistancy ++

3 changes:
- For better reading the log messages I made some changes in the log messages
- I also created 3 constants (version, data, algorithm) to modify easy when making a new release.
- added "--debug" in output when using "--help" 

The output will look now like below.
It's more easy to read, currently IMHO the log messages are a bit untidy to read.
Most log messages changes are before "Start mining".
In the future I send maybe some more consistency changes.

Thanks!

````
$ ./beam-opencl-miner --server beam.sparkpool.com:2222 --key foo.miningrig0
-====================================-
                                      
      BEAM Equihash OpenCL miner      
       version:   v1.0.63
       date:      Jan 6th 2019
       algorithm: Equihash 150,5
                                      
-====================================-

Parameters: 
 --server:      beam.sparkpool.com:2222
 --key:         foo.miningrig0
 --enable-cpu:  false
 --force3G:     false
 --debug:       false

Setup OpenCL devices:
=====================
Found device 0: GeForce GTX 1050 Ti
          Total memory: 4037 MByte
          Beam OpenCL kernel: using 4 Gbyte
          Beam OpenCL kernel: loading & compiling
          Beam OpenCL kernel: build sucessfully
Found device 1: Radeon RX 560 Series
          Total memory: 4033 MByte
          Free memory:  4014 MByte
          Beam OpenCL kernel: using 4 Gbyte
          Beam OpenCL kernel: loading & compiling
          Beam OpenCL kernel: build sucessfully          
Found device 2: Radeon RX 580 Series
          Device not used. Not included in --devices parameter.
Found device 3: AMD Radeon (TM) RX 480 Graphics
          Device not used. Not included in --devices parameter.

Waiting for work from stratum:
==============================
Connecting to beam.sparkpool.com:2222
Node connection: ok
TLS Handshake:   ok
New job: 1  Difficulty: 100
Solutions (Accepted/Rejected): 0 / 0 Uptime: 1 sec

Start mining:
=============
New job: 2  Difficulty: 100
Solutions (Accepted/Rejected): 0 / 0 Uptime: 6 sec
New job: 3  Difficulty: 100
Solutions (Accepted/Rejected): 0 / 0 Uptime: 16 sec
Performance: 2.40 sol/s 2.70 sol/s | Total: 5.10 sol/s 
New job: 4  Difficulty: 100
Solutions (Accepted/Rejected): 0 / 0 Uptime: 36 sec
Submitting solution to job 4 with nonce 719e3582e12175d8
Solution for work id 4 accepted
Solutions (Accepted/Rejected): 1 / 0 Uptime: 42 sec
Performance: 2.40 sol/s 2.70 sol/s | Total: 5.10 sol/s 
Submitting solution to job 4 with nonce 819e3582e12175d8
Solution for work id 4 accepted
...
````

````
$./beam-opencl-miner --help
-====================================-
      BEAM Equihash OpenCL miner      
             version: v1.0.63
             date:    Jan 6th 2019
                                       
      alogritm: Equihash 150,5
                                      
-====================================-

Parameters: 
 --server:      :
 --key:         
 --enable-cpu:  false
 --force3G:     false
 --debug:       false
Parameters: 
 --help / -h                    Showing this message
 --server <server>:<port>       The BEAM stratum server and port to connect to (required)
 --key <key>                    The BEAM stratum server API key (required)
 --devices <numbers>            A comma seperated list of devices that should be used for mining (default: all in system)
 --debug                        Enable debug mode - verbose information will be displayed
 --enable-cpu                   Enable mining on OpenCL CPU devices
 --force3G                      Force miner to use max 3G for all installed GPUs
 --version                      Prints the version number
$ 
````

